### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -6,19 +6,19 @@
 # Datatypes (KEYWORD1)
 #######################################
 
-Runtime KEYWORD1
-Service KEYWORD1
-CommunicationService KEYWORD1
-WifiService KEYWORD1
-ConfigurationService KEYWORD1
-InfoService KEYWORD1
-RGBService KEYWORD1
+Runtime	KEYWORD1
+Service	KEYWORD1
+CommunicationService	KEYWORD1
+WifiService	KEYWORD1
+ConfigurationService	KEYWORD1
+InfoService	KEYWORD1
+RGBService	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
-setName KEYWORD2
-registerService KEYWORD2
+setName	KEYWORD2
+registerService	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords